### PR TITLE
Functions naming consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,10 @@ language: php
 php:
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 
 script: vendor/bin/phpunit --verbose
-
-notifications
-  email:
-    on_success: [never]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-likeable` will be documented in this file.
 
+## 1.1.0 - 2016-09-08
+
+- Renamed `likeCounter()` to `likesCounter()` and `dislikeCounter()` to `dislikesCounter()` to follow code style consistency.
+
 ## 1.0.0 - 2016-09-07
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $article->likesCount;
 Get model likes counter
 
 ```php
-$article->likeCounter;
+$article->likesCounter;
 ```
 
 Get iterable `Illuminate\Database\Eloquent\Collection` of existing model likes
@@ -105,7 +105,7 @@ Find all articles liked by user
 
 ```php
 Article::whereLikedBy($user->id)
-	->with('likeCounter') // Allow eager load (optional)
+	->with('likesCounter') // Allow eager load (optional)
 	->get();
 ```
 
@@ -147,7 +147,7 @@ $article->dislikesCount;
 Get model dislikes counter
 
 ```php
-$article->dislikeCounter;
+$article->dislikesCounter;
 ```
 
 Get iterable `Illuminate\Database\Eloquent\Collection` of existing model dislikes
@@ -168,7 +168,7 @@ Find all articles disliked by user
 
 ```php
 Article::whereDislikedBy($user->id)
-	->with('likeCounter') // Allow eager load (optional)
+	->with('dislikesCounter') // Allow eager load (optional)
 	->get();
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "type": "library",
     "require": {
         "php": "^5.6|^7.0",
-        "illuminate/database": "~5.1.20|~5.2.0|~5.3.0"
+        "illuminate/database": "~5.1.20|~5.2.0|~5.3.0",
+        "illuminate/support": "~5.1.20|~5.2.0|~5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.2",

--- a/src/Contracts/HasLikes.php
+++ b/src/Contracts/HasLikes.php
@@ -44,14 +44,14 @@ interface HasLikes
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function likeCounter();
+    public function likesCounter();
 
     /**
      * Counter is a record that stores the total dislikes for the morphed record.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function dislikeCounter();
+    public function dislikesCounter();
 
     /**
      * Model likesCount attribute.

--- a/src/Services/LikeableService.php
+++ b/src/Services/LikeableService.php
@@ -147,7 +147,7 @@ class LikeableService implements LikeableServiceContract
      */
     public function decrementLikeCount(HasLikesContract $model)
     {
-        $counter = $model->likeCounter()->first();
+        $counter = $model->likesCounter()->first();
 
         if (!$counter) {
             return;
@@ -164,10 +164,10 @@ class LikeableService implements LikeableServiceContract
      */
     public function incrementLikeCount(HasLikesContract $model)
     {
-        $counter = $model->likeCounter()->first();
+        $counter = $model->likesCounter()->first();
 
         if (!$counter) {
-            $counter = $model->likeCounter()->create([
+            $counter = $model->likesCounter()->create([
                 'count' => 0,
                 'type_id' => LikeType::LIKE,
             ]);
@@ -184,7 +184,7 @@ class LikeableService implements LikeableServiceContract
      */
     public function decrementDislikeCount(HasLikesContract $model)
     {
-        $counter = $model->dislikeCounter()->first();
+        $counter = $model->dislikesCounter()->first();
 
         if (!$counter) {
             return;
@@ -201,10 +201,10 @@ class LikeableService implements LikeableServiceContract
      */
     public function incrementDislikeCount(HasLikesContract $model)
     {
-        $counter = $model->dislikeCounter()->first();
+        $counter = $model->dislikesCounter()->first();
 
         if (!$counter) {
-            $counter = $model->dislikeCounter()->create([
+            $counter = $model->dislikesCounter()->create([
                 'count' => 0,
                 'type_id' => LikeType::DISLIKE,
             ]);

--- a/src/Traits/HasLikes.php
+++ b/src/Traits/HasLikes.php
@@ -69,7 +69,7 @@ trait HasLikes
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function likeCounter()
+    public function likesCounter()
     {
         return $this->morphOne(app(LikeCounterContract::class), 'likeable')
             ->where('type_id', LikeType::LIKE);
@@ -80,7 +80,7 @@ trait HasLikes
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function dislikeCounter()
+    public function dislikesCounter()
     {
         return $this->morphOne(app(LikeCounterContract::class), 'likeable')
             ->where('type_id', LikeType::DISLIKE);
@@ -93,7 +93,7 @@ trait HasLikes
      */
     public function getLikesCountAttribute()
     {
-        return $this->likeCounter ? $this->likeCounter->count : 0;
+        return $this->likesCounter ? $this->likesCounter->count : 0;
     }
 
     /**
@@ -103,7 +103,7 @@ trait HasLikes
      */
     public function getDislikesCountAttribute()
     {
-        return $this->dislikeCounter ? $this->dislikeCounter->count : 0;
+        return $this->dislikesCounter ? $this->dislikesCounter->count : 0;
     }
 
     /**


### PR DESCRIPTION
- Renamed `likeCounter()` to `likesCounter()` and `dislikeCounter()` to `dislikesCounter()` to follow code style consistency.
- Added missed composer dependency `illuminate/support`.
- Fixed Travis-CI config file.
- Dropped HHVM tests. Added PHP 7.1 tests.
