### PR TITLE
Functions naming changed to follow code style consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-likeable` will be documented in this file.
 
+## 2.0.0 - 2016-09-11
+
+- Renamed `FollowableService` methods to follow code style consistency:
+    - `incrementLikeCount()` to `incrementLikesCount()`
+    - `decrementLikeCount()` to `decrementLikesCount()`
+    - `decrementDislikeCount()` to `decrementDislikesCount()`
+    - `incrementDislikeCount()` to `incrementDislikesCount()`
+
 ## 1.1.2 - 2016-09-07
 
 - Fix enum like types
@@ -12,7 +20,9 @@ All notable changes to `laravel-likeable` will be documented in this file.
 
 ## 1.1.0 - 2016-09-07
 
-- Renamed `likeCounter()` to `likesCounter()` and `dislikeCounter()` to `dislikesCounter()` to follow code style consistency.
+- Renamed `HasLikes` trait methods to follow code style consistency:
+    - `likeCounter()` to `likesCounter()`
+    - `dislikeCounter()` to `dislikesCounter()`
 
 ## 1.0.0 - 2016-09-06
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ php artisan migrate
 
 ## Usage
 
-### Prepare model
+### Prepare likeable model
 
 Use `HasLikes` contract in model which will get likes behavior and implement it or just use `HasLikes` trait. 
 
@@ -102,8 +102,8 @@ $article->likes;
 ##### Boolean check if user liked model
 
 ```php
-$article->liked; // check if currently logged in user liked the article
-$article->liked(); // check if currently logged in user liked the article
+$article->liked; // current user
+$article->liked(); // current user
 $article->liked($user->id);
 ```
 
@@ -171,8 +171,8 @@ $article->dislikes;
 ##### Boolean check if user disliked model
 
 ```php
-$article->disliked; // check if currently logged in user disliked the article
-$article->disliked(); // check if currently logged in user disliked the article
+$article->disliked; // current user
+$article->disliked(); // current user
 $article->disliked($user->id);
 ```
 

--- a/src/Contracts/LikeableService.php
+++ b/src/Contracts/LikeableService.php
@@ -72,7 +72,7 @@ interface LikeableService
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function decrementLikeCount(HasLikesContract $model);
+    public function decrementLikesCount(HasLikesContract $model);
 
     /**
      * Increment the total like count stored in the counter.
@@ -80,7 +80,7 @@ interface LikeableService
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function incrementLikeCount(HasLikesContract $model);
+    public function incrementLikesCount(HasLikesContract $model);
 
     /**
      * Decrement the total dislike count stored in the counter.
@@ -88,7 +88,7 @@ interface LikeableService
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function decrementDislikeCount(HasLikesContract $model);
+    public function decrementDislikesCount(HasLikesContract $model);
 
     /**
      * Increment the total dislike count stored in the counter.
@@ -96,7 +96,7 @@ interface LikeableService
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function incrementDislikeCount(HasLikesContract $model);
+    public function incrementDislikesCount(HasLikesContract $model);
 
     /**
      * Remove like counters by likeable type.

--- a/src/Observers/LikeObserver.php
+++ b/src/Observers/LikeObserver.php
@@ -36,10 +36,10 @@ class LikeObserver
     {
         if ($like->type_id == LikeType::LIKE) {
             event(new ModelWasLiked($like->likeable, $like->user_id));
-            app(LikeableServiceContract::class)->incrementLikeCount($like->likeable, $like->type_id);
+            app(LikeableServiceContract::class)->incrementLikesCount($like->likeable, $like->type_id);
         } else {
             event(new ModelWasDisliked($like->likeable, $like->user_id));
-            app(LikeableServiceContract::class)->incrementDislikeCount($like->likeable, $like->type_id);
+            app(LikeableServiceContract::class)->incrementDislikesCount($like->likeable, $like->type_id);
         }
     }
 
@@ -53,10 +53,10 @@ class LikeObserver
     {
         if ($like->type_id == LikeType::LIKE) {
             event(new ModelWasUnliked($like->likeable, $like->user_id));
-            app(LikeableServiceContract::class)->decrementLikeCount($like->likeable, $like->type_id);
+            app(LikeableServiceContract::class)->decrementLikesCount($like->likeable, $like->type_id);
         } else {
             event(new ModelWasUndisliked($like->likeable, $like->user_id));
-            app(LikeableServiceContract::class)->decrementDislikeCount($like->likeable, $like->type_id);
+            app(LikeableServiceContract::class)->decrementDislikesCount($like->likeable, $like->type_id);
         }
     }
 }

--- a/src/Services/LikeableService.php
+++ b/src/Services/LikeableService.php
@@ -148,7 +148,7 @@ class LikeableService implements LikeableServiceContract
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function decrementLikeCount(HasLikesContract $model)
+    public function decrementLikesCount(HasLikesContract $model)
     {
         $counter = $model->likesCounter()->first();
 
@@ -165,7 +165,7 @@ class LikeableService implements LikeableServiceContract
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function incrementLikeCount(HasLikesContract $model)
+    public function incrementLikesCount(HasLikesContract $model)
     {
         $counter = $model->likesCounter()->first();
 
@@ -185,7 +185,7 @@ class LikeableService implements LikeableServiceContract
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function decrementDislikeCount(HasLikesContract $model)
+    public function decrementDislikesCount(HasLikesContract $model)
     {
         $counter = $model->dislikesCounter()->first();
 
@@ -202,7 +202,7 @@ class LikeableService implements LikeableServiceContract
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function incrementDislikeCount(HasLikesContract $model)
+    public function incrementDislikesCount(HasLikesContract $model)
     {
         $counter = $model->dislikesCounter()->first();
 

--- a/tests/unit/Services/LikeableServiceTest.php
+++ b/tests/unit/Services/LikeableServiceTest.php
@@ -44,8 +44,8 @@ class LikeableServiceTest extends TestCase
         $entity->like(1);
         $entity->like(2);
 
-        $service->decrementLikeCount($entity);
-        $service->decrementLikeCount($entity);
+        $service->decrementLikesCount($entity);
+        $service->decrementLikesCount($entity);
 
         $this->assertEquals(0, $entity->likesCount);
     }
@@ -56,7 +56,7 @@ class LikeableServiceTest extends TestCase
         $service = $this->app->make(LikeableServiceContract::class);
         $entity = factory(Entity::class)->create();
 
-        $service->decrementLikeCount($entity);
+        $service->decrementLikesCount($entity);
 
         $this->assertEquals(0, $entity->likesCount);
     }
@@ -67,8 +67,8 @@ class LikeableServiceTest extends TestCase
         $service = $this->app->make(LikeableServiceContract::class);
         $entity = factory(Entity::class)->create();
 
-        $service->incrementLikeCount($entity);
-        $service->incrementLikeCount($entity);
+        $service->incrementLikesCount($entity);
+        $service->incrementLikesCount($entity);
 
         $this->assertEquals(2, $entity->likesCount);
     }


### PR DESCRIPTION
Renamed `FollowableService` methods to follow code style consistency:
- `incrementLikeCount()` to `incrementLikesCount()`
- `decrementLikeCount()` to `decrementLikesCount()`
- `decrementDislikeCount()` to `decrementDislikesCount()`
- `incrementDislikeCount()` to `incrementDislikesCount()`
