### PR TITLE
Refactored LikeCounter entities and related methods to LikersCounter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to `laravel-likeable` will be documented in this file.
 
+## 3.0.0 - 2016-09-12
+
+`LikeCounter` entity renamed to `LikersCounter` to be more intuitive and provide more extensibility for package.
+
+- Renamed database table `like_counter` to `liker_counter`
+- Renamed `LikeCounter` to `LikerCounter` model
+- Renamed `HasLikes` trait methods:
+    - `likesCounter()` to `likersCounter()`
+    - `dislikesCounter()` to `dislikersCounter()`
+    - `getLikesCountAttribute()` to `getLikersCountAttribute()`
+    - `getDislikesCountAttribute()` to `getDislikersCountAttribute()`
+    - `getLikesDiffDislikesCountAttribute()` to `getLikersDiffDislikersCountAttribute()`
+- Renamed `LikeableService` methods:
+    - `decrementLikesCount()` to `decrementLikersCount()`
+    - `decrementDislikesCount()` to `decrementDislikersCount()`
+    - `incrementLikesCount()` to `incrementLikersCount()`
+    - `incrementDislikesCount()` to `incrementDislikersCount()`
+    - `removeLikeCountersOfType()` to `removeLikerCountersOfType()`
+    - `fetchLikesCounters()` to `fetchLikersCounters()`
+
 ## 2.0.0 - 2016-09-11
 
 - Renamed `FollowableService` methods to follow code style consistency:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@
 
 Trait for Laravel Eloquent models to allow easy implementation of a `like` & `dislike` features.
 
-*Note: Likes and dislikes for one model by one user are mutually exclusive.*
-
 ![cybercog-laravel-likeable](https://cloud.githubusercontent.com/assets/1849174/18293813/cf2ffafc-749d-11e6-912f-e827c3b50c50.png)
+
+## Features
+
+- Designed to work with Laravel Eloquent models.
+- Using contracts to keep high customization capabilities.
+- Using traits to get functionality out of the box.
+- Most part of the the logic is handled by the `LikeableService`.
+- Has Artisan command `likeable:recount {model?} {type?}` to re-fetch likes counters.
+- Likeable model can has Likes and Dislikes.
+- Likes and Dislikes for one model are mutually exclusive.
+- Events for `like`, `unlike`, `dislike`, `undislike` methods.
+- Covered with unit tests.
 
 ## Installation
 
@@ -339,6 +349,8 @@ If you discover any security related issues, please email [support@cybercog.su](
 - [rtconner/laravel-likeable](https://github.com/rtconner/laravel-likeable)
 - [draperstudio/laravel-likeable](https://github.com/DraperStudio/Laravel-Likeable)
 - [sukohi/evaluation](https://github.com/SUKOHI/Evaluation)
+
+*Feel free to add more alternatives as Pull Request.*
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ $article->likeToggle($user->id);
 ##### Get model likes count
 
 ```php
-$article->likesCount;
+$article->likersCount;
 ```
 
 ##### Get model likes counter
 
 ```php
-$article->likesCounter;
+$article->likersCounter;
 ```
 
 ##### Get likes relation
@@ -111,7 +111,7 @@ $article->liked($user->id);
 
 ```php
 Article::whereLikedBy($user->id)
-	->with('likesCounter') // Allow eager load (optional)
+	->with('likersCounter') // Allow eager load (optional)
 	->get();
 ```
 
@@ -147,13 +147,13 @@ $article->dislikeToggle($user->id);
 ##### Get model dislikes count
 
 ```php
-$article->dislikesCount;
+$article->dislikersCount;
 ```
 
 ##### Get model dislikes counter
 
 ```php
-$article->dislikesCounter;
+$article->dislikersCounter;
 ```
 
 ##### Get dislikes relation
@@ -180,7 +180,7 @@ $article->disliked($user->id);
 
 ```php
 Article::whereDislikedBy($user->id)
-	->with('dislikesCounter') // Allow eager load (optional)
+	->with('dislikersCounter') // Allow eager load (optional)
 	->get();
 ```
 
@@ -195,7 +195,7 @@ $article->removeDislikes();
 ##### Get difference between likes and dislikes
 
 ```php
-$article->likesDiffDislikesCount;
+$article->likersDiffDislikersCount;
 ```
 
 ##### Get likes and dislikes relation

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,11 @@
 {
     "name": "cybercog/laravel-likeable",
     "description": "Trait for Laravel Eloquent models to allow easy implementation of a `like` & `dislike` features.",
+    "type": "library",
+    "license": "BSD-3-Clause",
     "keywords": [
+        "cybercog",
+        "cog",
         "trait",
         "laravel",
         "eloquent",
@@ -12,7 +16,9 @@
         "favorite",
         "favourite",
         "rate",
-        "rating"
+        "rating",
+        "star",
+        "kudos"
     ],
     "authors": [
         {
@@ -22,18 +28,24 @@
             "role": "Developer"
         }
     ],
-    "license": "BSD-3-Clause",
-    "type": "library",
+    "homepage": "https://github.com/cybercog/laravel-likeable",
+    "support": {
+        "email": "a.komarev@cybercog.su",
+        "issues": "https://github.com/cybercog/laravel-likeable/issues",
+        "wiki": "https://github.com/cybercog/laravel-likeable/wiki",
+        "source": "https://github.com/cybercog/laravel-likeable",
+        "docs": "https://github.com/cybercog/laravel-likeable/wiki"
+    },
     "require": {
         "php": "^5.6|^7.0",
         "illuminate/database": "~5.1.20|~5.2.0|~5.3.0",
         "illuminate/support": "~5.1.20|~5.2.0|~5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.2",
+        "friendsofphp/php-cs-fixer": "^1.11",
+        "mockery/mockery": "^0.9.5",
         "orchestra/testbench": "~3.0",
-        "mockery/mockery": "~0.9",
-        "friendsofphp/php-cs-fixer": "^1.11"
+        "phpunit/phpunit": "^5.2"
     },
     "autoload": {
         "psr-4": {
@@ -44,5 +56,8 @@
         "psr-4": {
             "Cog\\Likeable\\Tests\\": "tests/"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/database/migrations/2016_09_02_153301_create_like_table.php
+++ b/database/migrations/2016_09_02_153301_create_like_table.php
@@ -9,11 +9,20 @@
  * file that was distributed with this source code.
  */
 
-use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
+/**
+ * Class CreateLikeTable.
+ */
 class CreateLikeTable extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('like', function (Blueprint $table) {
@@ -37,8 +46,13 @@ class CreateLikeTable extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
-        Schema::drop('like');
+        Schema::dropIfExists('like');
     }
 }

--- a/database/migrations/2016_09_02_163301_create_like_counter_table.php
+++ b/database/migrations/2016_09_02_163301_create_like_counter_table.php
@@ -9,11 +9,20 @@
  * file that was distributed with this source code.
  */
 
-use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
+/**
+ * Class CreateLikeCounterTable.
+ */
 class CreateLikeCounterTable extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('like_counter', function (Blueprint $table) {
@@ -34,8 +43,13 @@ class CreateLikeCounterTable extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
-        Schema::drop('like_counter');
+        Schema::dropIfExists('like_counter');
     }
 }

--- a/database/migrations/2016_09_12_000000_rename_like_counter_table.php
+++ b/database/migrations/2016_09_12_000000_rename_like_counter_table.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Laravel Likeable.
+ *
+ * (c) CyberCog <support@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+
+class RenameLikeCounterTable extends Migration
+{
+    public function up()
+    {
+        Schema::rename('like_counter', 'likers_counter');
+    }
+
+    public function down()
+    {
+        Schema::drop('liker_counter');
+    }
+}

--- a/database/migrations/2016_09_12_000000_rename_like_counter_table.php
+++ b/database/migrations/2016_09_12_000000_rename_like_counter_table.php
@@ -9,17 +9,31 @@
  * file that was distributed with this source code.
  */
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Migrations\Migration;
 
+/**
+ * Class RenameLikeCounterTable.
+ */
 class RenameLikeCounterTable extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::rename('like_counter', 'likers_counter');
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
-        Schema::drop('liker_counter');
+        Schema::rename('likers_counter', 'like_counter');
     }
 }

--- a/src/Console/LikeableRecountCommand.php
+++ b/src/Console/LikeableRecountCommand.php
@@ -70,6 +70,7 @@ class LikeableRecountCommand extends Command
 
         if (!empty($model)) {
             $this->recountLikesOfModelType($model);
+
             return;
         }
 

--- a/src/Console/LikeableRecountCommand.php
+++ b/src/Console/LikeableRecountCommand.php
@@ -59,22 +59,22 @@ class LikeableRecountCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param \Illuminate\Contracts\Events\Dispatcher $events
      * @return void
      *
      * @throws \Cog\Likeable\Exceptions\ModelInvalidException
      */
-    public function handle(Dispatcher $events)
+    public function handle()
     {
         $model = $this->argument('model');
         $this->likeType = $this->argument('type');
         $this->service = app(LikeableServiceContract::class);
 
-        if (empty($model)) {
-            $this->recountLikesOfAllModelTypes();
-        } else {
+        if (!empty($model)) {
             $this->recountLikesOfModelType($model);
+            return;
         }
+
+        $this->recountLikesOfAllModelTypes();
     }
 
     /**
@@ -113,6 +113,14 @@ class LikeableRecountCommand extends Command
         $this->info('All [' . $modelType . '] records likes has been recounted.');
     }
 
+    /**
+     * Normalize model type.
+     *
+     * @param $modelType
+     * @return string
+     *
+     * @throws \Cog\Likeable\Exceptions\ModelInvalidException
+     */
     protected function normalizeModelType($modelType)
     {
         $morphMap = Relation::morphMap();

--- a/src/Console/LikeableRecountCommand.php
+++ b/src/Console/LikeableRecountCommand.php
@@ -17,7 +17,6 @@ use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 use Cog\Likeable\Exceptions\ModelInvalidException;
 use Cog\Likeable\Services\LikeableService as LikeableServiceContract;
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\DB;
 

--- a/src/Console/LikeableRecountCommand.php
+++ b/src/Console/LikeableRecountCommand.php
@@ -11,14 +11,14 @@
 
 namespace Cog\Likeable\Console;
 
-use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
-use Cog\Likeable\Contracts\Like as LikeContract;
-use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
-use Cog\Likeable\Exceptions\ModelInvalidException;
-use Cog\Likeable\Services\LikeableService as LikeableServiceContract;
 use Illuminate\Console\Command;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\DB;
+use Cog\Likeable\Contracts\Like as LikeContract;
+use Cog\Likeable\Exceptions\ModelInvalidException;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
+use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
+use Cog\Likeable\Services\LikeableService as LikeableServiceContract;
 
 /**
  * Class LikeableRecountCommand.

--- a/src/Console/LikeableRecountCommand.php
+++ b/src/Console/LikeableRecountCommand.php
@@ -13,7 +13,7 @@ namespace Cog\Likeable\Console;
 
 use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 use Cog\Likeable\Contracts\Like as LikeContract;
-use Cog\Likeable\Contracts\LikeCounter as LikeCounterContract;
+use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 use Cog\Likeable\Exceptions\ModelInvalidException;
 use Cog\Likeable\Services\LikeableService as LikeableServiceContract;
 use Illuminate\Console\Command;
@@ -104,11 +104,11 @@ class LikeableRecountCommand extends Command
     {
         $modelType = $this->normalizeModelType($modelType);
 
-        $counters = $this->service->fetchLikesCounters($modelType, $this->likeType);
+        $counters = $this->service->fetchLikersCounters($modelType, $this->likeType);
 
-        $this->service->removeLikeCountersOfType($modelType, $this->likeType);
+        $this->service->removeLikersCountersOfType($modelType, $this->likeType);
 
-        DB::table(app(LikeCounterContract::class)->getTable())->insert($counters);
+        DB::table(app(LikersCounterContract::class)->getTable())->insert($counters);
 
         $this->info('All [' . $modelType . '] records likes has been recounted.');
     }

--- a/src/Contracts/HasLikes.php
+++ b/src/Contracts/HasLikes.php
@@ -40,32 +40,32 @@ interface HasLikes
     public function dislikes();
 
     /**
-     * Counter is a record that stores the total likes for the morphed record.
+     * Counter is a record that stores the total likers count for the morphed record.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function likesCounter();
+    public function likersCounter();
 
     /**
-     * Counter is a record that stores the total dislikes for the morphed record.
+     * Counter is a record that stores the total dislikers count for the morphed record.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function dislikesCounter();
+    public function dislikersCounter();
 
     /**
-     * Model likesCount attribute.
+     * Model likersCount attribute.
      *
      * @return int
      */
-    public function getLikesCountAttribute();
+    public function getLikersCountAttribute();
 
     /**
-     * Model dislikesCount attribute.
+     * Model dislikersCount attribute.
      *
      * @return int
      */
-    public function getDislikesCountAttribute();
+    public function getDislikersCountAttribute();
 
     /**
      * Did the currently logged in user like this model.
@@ -86,7 +86,7 @@ interface HasLikes
      *
      * @return int
      */
-    public function getLikesDiffDislikesCountAttribute();
+    public function getLikersDiffDislikersCountAttribute();
 
     /**
      * Fetch records that are liked by a given user id.

--- a/src/Contracts/HasLikes.php
+++ b/src/Contracts/HasLikes.php
@@ -19,6 +19,20 @@ namespace Cog\Likeable\Contracts;
 interface HasLikes
 {
     /**
+     * Get the value of the model's primary key.
+     *
+     * @return mixed
+     */
+    public function getKey();
+
+    /**
+     * Get the class name for polymorphic relations.
+     *
+     * @return string
+     */
+    public function getMorphClass();
+
+    /**
      * Collection of the likes on this record.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany

--- a/src/Contracts/LikeableService.php
+++ b/src/Contracts/LikeableService.php
@@ -67,45 +67,45 @@ interface LikeableService
     public function isLiked(HasLikesContract $model, $type, $userId);
 
     /**
-     * Decrement the total like count stored in the counter.
+     * Decrement the total likers count stored in the counter.
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function decrementLikesCount(HasLikesContract $model);
+    public function decrementLikersCount(HasLikesContract $model);
 
     /**
-     * Increment the total like count stored in the counter.
+     * Increment the total likers count stored in the counter.
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function incrementLikesCount(HasLikesContract $model);
+    public function incrementLikersCount(HasLikesContract $model);
 
     /**
-     * Decrement the total dislike count stored in the counter.
+     * Decrement the total dislikers count stored in the counter.
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function decrementDislikesCount(HasLikesContract $model);
+    public function decrementDislikersCount(HasLikesContract $model);
 
     /**
-     * Increment the total dislike count stored in the counter.
+     * Increment the total dislikers count stored in the counter.
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function incrementDislikesCount(HasLikesContract $model);
+    public function incrementDislikersCount(HasLikesContract $model);
 
     /**
-     * Remove like counters by likeable type.
+     * Remove liker counters by likeable type.
      *
      * @param string $likeableType
      * @param string|null $type
      * @return void
      */
-    public function removeLikeCountersOfType($likeableType, $type = null);
+    public function removeLikersCountersOfType($likeableType, $type = null);
 
     /**
      * Remove all likes from likeable model.
@@ -129,11 +129,11 @@ interface LikeableService
     public function scopeWhereLikedBy($query, $type, $userId);
 
     /**
-     * Fetch likes counters data.
+     * Fetch likers counters data.
      *
      * @param string $likeableType
      * @param string $likeType
      * @return array
      */
-    public function fetchLikesCounters($likeableType, $likeType);
+    public function fetchLikersCounters($likeableType, $likeType);
 }

--- a/src/Contracts/LikeableService.php
+++ b/src/Contracts/LikeableService.php
@@ -12,6 +12,7 @@
 namespace Cog\Likeable\Contracts;
 
 use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Interface LikeableService.
@@ -119,14 +120,14 @@ interface LikeableService
     /**
      * Fetch records that are liked by a given user id.
      *
-     * @param \Illuminate\Database\Query\Builder $query
+     * @param \Illuminate\Database\Eloquent\Builder $query
      * @param string $type
      * @param int|null $userId
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Eloquent\Builder
      *
      * @throws \Cog\Likeable\Exceptions\LikerNotDefinedException
      */
-    public function scopeWhereLikedBy($query, $type, $userId);
+    public function scopeWhereLikedBy(Builder $query, $type, $userId);
 
     /**
      * Fetch likers counters data.

--- a/src/Contracts/LikeableService.php
+++ b/src/Contracts/LikeableService.php
@@ -11,8 +11,8 @@
 
 namespace Cog\Likeable\Contracts;
 
-use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 use Illuminate\Database\Eloquent\Builder;
+use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 
 /**
  * Interface LikeableService.

--- a/src/Contracts/LikersCounter.php
+++ b/src/Contracts/LikersCounter.php
@@ -12,13 +12,13 @@
 namespace Cog\Likeable\Contracts;
 
 /**
- * Interface LikeCounter.
+ * Interface LikersCounter.
  *
  * @property int type_id
  * @property int count
  * @package Cog\Likeable\Contracts
  */
-interface LikeCounter
+interface LikersCounter
 {
     /**
      * Likeable model relation.

--- a/src/Events/ModelWasDisliked.php
+++ b/src/Events/ModelWasDisliked.php
@@ -39,7 +39,6 @@ class ModelWasDisliked
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @param int $likerId
-     * @return void
      */
     public function __construct(HasLikesContract $model, $likerId)
     {

--- a/src/Events/ModelWasLiked.php
+++ b/src/Events/ModelWasLiked.php
@@ -39,7 +39,6 @@ class ModelWasLiked
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @param int $likerId
-     * @return void
      */
     public function __construct(HasLikesContract $model, $likerId)
     {

--- a/src/Events/ModelWasUndisliked.php
+++ b/src/Events/ModelWasUndisliked.php
@@ -39,7 +39,6 @@ class ModelWasUndisliked
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @param int $likerId
-     * @return void
      */
     public function __construct(HasLikesContract $model, $likerId)
     {

--- a/src/Events/ModelWasUnliked.php
+++ b/src/Events/ModelWasUnliked.php
@@ -39,7 +39,6 @@ class ModelWasUnliked
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @param int $likerId
-     * @return void
      */
     public function __construct(HasLikesContract $model, $likerId)
     {

--- a/src/Models/Like.php
+++ b/src/Models/Like.php
@@ -11,8 +11,8 @@
 
 namespace Cog\Likeable\Models;
 
-use Cog\Likeable\Contracts\Like as LikeContract;
 use Illuminate\Database\Eloquent\Model;
+use Cog\Likeable\Contracts\Like as LikeContract;
 
 /**
  * Class Like.

--- a/src/Models/LikersCounter.php
+++ b/src/Models/LikersCounter.php
@@ -11,8 +11,8 @@
 
 namespace Cog\Likeable\Models;
 
-use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 use Illuminate\Database\Eloquent\Model;
+use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 
 /**
  * Class LikersCounter.

--- a/src/Models/LikersCounter.php
+++ b/src/Models/LikersCounter.php
@@ -11,17 +11,17 @@
 
 namespace Cog\Likeable\Models;
 
-use Cog\Likeable\Contracts\LikeCounter as LikeCounterContract;
+use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Class LikeCounter.
+ * Class LikersCounter.
  *
  * @property int type_id
  * @property int count
  * @package Cog\Likeable\Models
  */
-class LikeCounter extends Model implements LikeCounterContract
+class LikersCounter extends Model implements LikersCounterContract
 {
     /**
      * Indicates if the model should be timestamped.
@@ -35,7 +35,7 @@ class LikeCounter extends Model implements LikeCounterContract
      *
      * @var string
      */
-    protected $table = 'like_counter';
+    protected $table = 'likers_counter';
 
     /**
      * The attributes that are mass assignable.

--- a/src/Observers/LikeObserver.php
+++ b/src/Observers/LikeObserver.php
@@ -36,10 +36,10 @@ class LikeObserver
     {
         if ($like->type_id == LikeType::LIKE) {
             event(new ModelWasLiked($like->likeable, $like->user_id));
-            app(LikeableServiceContract::class)->incrementLikesCount($like->likeable, $like->type_id);
+            app(LikeableServiceContract::class)->incrementLikersCount($like->likeable, $like->type_id);
         } else {
             event(new ModelWasDisliked($like->likeable, $like->user_id));
-            app(LikeableServiceContract::class)->incrementDislikesCount($like->likeable, $like->type_id);
+            app(LikeableServiceContract::class)->incrementDislikersCount($like->likeable, $like->type_id);
         }
     }
 
@@ -53,10 +53,10 @@ class LikeObserver
     {
         if ($like->type_id == LikeType::LIKE) {
             event(new ModelWasUnliked($like->likeable, $like->user_id));
-            app(LikeableServiceContract::class)->decrementLikesCount($like->likeable, $like->type_id);
+            app(LikeableServiceContract::class)->decrementLikersCount($like->likeable, $like->type_id);
         } else {
             event(new ModelWasUndisliked($like->likeable, $like->user_id));
-            app(LikeableServiceContract::class)->decrementDislikesCount($like->likeable, $like->type_id);
+            app(LikeableServiceContract::class)->decrementDislikersCount($like->likeable, $like->type_id);
         }
     }
 }

--- a/src/Observers/LikeObserver.php
+++ b/src/Observers/LikeObserver.php
@@ -12,10 +12,10 @@
 namespace Cog\Likeable\Observers;
 
 use Cog\Likeable\Enums\LikeType;
-use Cog\Likeable\Events\ModelWasDisliked;
 use Cog\Likeable\Events\ModelWasLiked;
-use Cog\Likeable\Events\ModelWasUndisliked;
 use Cog\Likeable\Events\ModelWasUnliked;
+use Cog\Likeable\Events\ModelWasDisliked;
+use Cog\Likeable\Events\ModelWasUndisliked;
 use Cog\Likeable\Contracts\Like as LikeContract;
 use Cog\Likeable\Contracts\LikeableService as LikeableServiceContract;
 

--- a/src/Providers/LikeableServiceProvider.php
+++ b/src/Providers/LikeableServiceProvider.php
@@ -11,15 +11,15 @@
 
 namespace Cog\Likeable\Providers;
 
-use Cog\Likeable\Console\LikeableRecountCommand;
-use Cog\Likeable\Contracts\Like as LikeContract;
-use Cog\Likeable\Contracts\LikeableService as LikeableServiceContract;
-use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 use Cog\Likeable\Models\Like;
 use Cog\Likeable\Models\LikersCounter;
+use Illuminate\Support\ServiceProvider;
 use Cog\Likeable\Observers\LikeObserver;
 use Cog\Likeable\Services\LikeableService;
-use Illuminate\Support\ServiceProvider;
+use Cog\Likeable\Console\LikeableRecountCommand;
+use Cog\Likeable\Contracts\Like as LikeContract;
+use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
+use Cog\Likeable\Contracts\LikeableService as LikeableServiceContract;
 
 /**
  * Class LikeableServiceProvider.

--- a/src/Providers/LikeableServiceProvider.php
+++ b/src/Providers/LikeableServiceProvider.php
@@ -14,9 +14,9 @@ namespace Cog\Likeable\Providers;
 use Cog\Likeable\Console\LikeableRecountCommand;
 use Cog\Likeable\Contracts\Like as LikeContract;
 use Cog\Likeable\Contracts\LikeableService as LikeableServiceContract;
-use Cog\Likeable\Contracts\LikeCounter as LikeCounterContract;
+use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 use Cog\Likeable\Models\Like;
-use Cog\Likeable\Models\LikeCounter;
+use Cog\Likeable\Models\LikersCounter;
 use Cog\Likeable\Observers\LikeObserver;
 use Cog\Likeable\Services\LikeableService;
 use Illuminate\Support\ServiceProvider;
@@ -54,7 +54,7 @@ class LikeableServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind(LikeContract::class, Like::class);
-        $this->app->bind(LikeCounterContract::class, LikeCounter::class);
+        $this->app->bind(LikersCounterContract::class, LikersCounter::class);
         $this->app->singleton(LikeableServiceContract::class, LikeableService::class);
     }
 

--- a/src/Services/LikeableService.php
+++ b/src/Services/LikeableService.php
@@ -14,7 +14,7 @@ namespace Cog\Likeable\Services;
 use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 use Cog\Likeable\Contracts\Like as LikeContract;
 use Cog\Likeable\Contracts\LikeableService as LikeableServiceContract;
-use Cog\Likeable\Contracts\LikeCounter as LikeCounterContract;
+use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 use Cog\Likeable\Enums\LikeType;
 use Cog\Likeable\Exceptions\LikerNotDefinedException;
 use Cog\Likeable\Exceptions\LikeTypeInvalidException;
@@ -143,14 +143,14 @@ class LikeableService implements LikeableServiceContract
     }
 
     /**
-     * Decrement the total like count stored in the counter.
+     * Decrement the total likers count stored in the counter.
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function decrementLikesCount(HasLikesContract $model)
+    public function decrementLikersCount(HasLikesContract $model)
     {
-        $counter = $model->likesCounter()->first();
+        $counter = $model->likersCounter()->first();
 
         if (!$counter) {
             return;
@@ -160,17 +160,17 @@ class LikeableService implements LikeableServiceContract
     }
 
     /**
-     * Increment the total like count stored in the counter.
+     * Increment the total likers count stored in the counter.
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function incrementLikesCount(HasLikesContract $model)
+    public function incrementLikersCount(HasLikesContract $model)
     {
-        $counter = $model->likesCounter()->first();
+        $counter = $model->likersCounter()->first();
 
         if (!$counter) {
-            $counter = $model->likesCounter()->create([
+            $counter = $model->likersCounter()->create([
                 'count' => 0,
                 'type_id' => LikeType::LIKE,
             ]);
@@ -180,14 +180,14 @@ class LikeableService implements LikeableServiceContract
     }
 
     /**
-     * Decrement the total dislike count stored in the counter.
+     * Decrement the total dislikers count stored in the counter.
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function decrementDislikesCount(HasLikesContract $model)
+    public function decrementDislikersCount(HasLikesContract $model)
     {
-        $counter = $model->dislikesCounter()->first();
+        $counter = $model->dislikersCounter()->first();
 
         if (!$counter) {
             return;
@@ -197,17 +197,17 @@ class LikeableService implements LikeableServiceContract
     }
 
     /**
-     * Increment the total dislike count stored in the counter.
+     * Increment the total dislikers count stored in the counter.
      *
      * @param \Cog\Likeable\Contracts\HasLikes $model
      * @return void
      */
-    public function incrementDislikesCount(HasLikesContract $model)
+    public function incrementDislikersCount(HasLikesContract $model)
     {
-        $counter = $model->dislikesCounter()->first();
+        $counter = $model->dislikersCounter()->first();
 
         if (!$counter) {
-            $counter = $model->dislikesCounter()->create([
+            $counter = $model->dislikersCounter()->create([
                 'count' => 0,
                 'type_id' => LikeType::DISLIKE,
             ]);
@@ -223,14 +223,14 @@ class LikeableService implements LikeableServiceContract
      * @param string|null $type
      * @return void
      */
-    public function removeLikeCountersOfType($likeableType, $type = null)
+    public function removeLikersCountersOfType($likeableType, $type = null)
     {
         if (class_exists($likeableType)) {
             $model = new $likeableType;
             $likeableType = $model->getMorphClass();
         }
 
-        $counters = app(LikeCounterContract::class)->where('likeable_type', $likeableType);
+        $counters = app(LikersCounterContract::class)->where('likeable_type', $likeableType);
         if (!is_null($type)) {
             $counters->where('type_id', $this->getLikeTypeId($type));
         }
@@ -252,7 +252,7 @@ class LikeableService implements LikeableServiceContract
             'type_id' => $this->getLikeTypeId($type),
         ])->delete();
 
-        app(LikeCounterContract::class)->where([
+        app(LikersCounterContract::class)->where([
             'likeable_id' => $model->getKey(),
             'likeable_type' => $model->getMorphClass(),
             'type_id' => $this->getLikeTypeId($type),
@@ -282,15 +282,15 @@ class LikeableService implements LikeableServiceContract
     }
 
     /**
-     * Fetch likes counters data.
+     * Fetch likers counters data.
      *
      * @param string $likeableType
      * @param string $likeType
      * @return array
      */
-    public function fetchLikesCounters($likeableType, $likeType)
+    public function fetchLikersCounters($likeableType, $likeType)
     {
-        $likesCount = app(LikeContract::class)->query()
+        $likersCounters = app(LikeContract::class)->query()
             ->select([
                 DB::raw('COUNT(*) AS count'),
                 'likeable_type',
@@ -300,14 +300,12 @@ class LikeableService implements LikeableServiceContract
             ->where('likeable_type', $likeableType);
 
         if (!is_null($likeType)) {
-            $likesCount->where('type_id', $this->getLikeTypeId($likeType));
+            $likersCounters->where('type_id', $this->getLikeTypeId($likeType));
         }
 
-        $likesCount->groupBy('likeable_id', 'type_id');
+        $likersCounters->groupBy('likeable_id', 'type_id');
 
-        $counters = $likesCount->get()->toArray();
-
-        return $counters;
+        return $likersCounters->get()->toArray();
     }
 
     /**

--- a/src/Services/LikeableService.php
+++ b/src/Services/LikeableService.php
@@ -19,6 +19,7 @@ use Cog\Likeable\Enums\LikeType;
 use Cog\Likeable\Exceptions\LikerNotDefinedException;
 use Cog\Likeable\Exceptions\LikeTypeInvalidException;
 use DB;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Class LikeableService.
@@ -262,18 +263,18 @@ class LikeableService implements LikeableServiceContract
     /**
      * Fetch records that are liked by a given user id.
      *
-     * @param \Illuminate\Database\Query\Builder $query
+     * @param \Illuminate\Database\Eloquent\Builder $query
      * @param string $type
      * @param int|null $userId
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Eloquent\Builder
      *
      * @throws \Cog\Likeable\Exceptions\LikerNotDefinedException
      */
-    public function scopeWhereLikedBy($query, $type, $userId)
+    public function scopeWhereLikedBy(Builder $query, $type, $userId)
     {
         $userId = $this->getLikerUserId($userId);
 
-        return $query->whereHas('likesAndDislikes', function ($q) use ($type, $userId) {
+        return $query->whereHas('likesAndDislikes', function (Builder $q) use ($type, $userId) {
             $q->where([
                 'user_id' => $userId,
                 'type_id' => $this->getLikeTypeId($type),

--- a/src/Services/LikeableService.php
+++ b/src/Services/LikeableService.php
@@ -11,15 +11,15 @@
 
 namespace Cog\Likeable\Services;
 
-use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
-use Cog\Likeable\Contracts\Like as LikeContract;
-use Cog\Likeable\Contracts\LikeableService as LikeableServiceContract;
-use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 use Cog\Likeable\Enums\LikeType;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Builder;
+use Cog\Likeable\Contracts\Like as LikeContract;
 use Cog\Likeable\Exceptions\LikerNotDefinedException;
 use Cog\Likeable\Exceptions\LikeTypeInvalidException;
-use DB;
-use Illuminate\Database\Eloquent\Builder;
+use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
+use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
+use Cog\Likeable\Contracts\LikeableService as LikeableServiceContract;
 
 /**
  * Class LikeableService.

--- a/src/Traits/HasLikes.php
+++ b/src/Traits/HasLikes.php
@@ -13,7 +13,7 @@ namespace Cog\Likeable\Traits;
 
 use Cog\Likeable\Contracts\Like as LikeContract;
 use Cog\Likeable\Contracts\LikeableService as LikeableServiceContract;
-use Cog\Likeable\Contracts\LikeCounter as LikeCounterContract;
+use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 use Cog\Likeable\Enums\LikeType;
 use Cog\Likeable\Observers\ModelObserver;
 
@@ -65,45 +65,45 @@ trait HasLikes
     }
 
     /**
-     * Counter is a record that stores the total likes for the morphed record.
+     * Counter is a record that stores the total likers count for the morphed record.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function likesCounter()
+    public function likersCounter()
     {
-        return $this->morphOne(app(LikeCounterContract::class), 'likeable')
+        return $this->morphOne(app(LikersCounterContract::class), 'likeable')
             ->where('type_id', LikeType::LIKE);
     }
 
     /**
-     * Counter is a record that stores the total dislikes for the morphed record.
+     * Counter is a record that stores the total dislikers count for the morphed record.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function dislikesCounter()
+    public function dislikersCounter()
     {
-        return $this->morphOne(app(LikeCounterContract::class), 'likeable')
+        return $this->morphOne(app(LikersCounterContract::class), 'likeable')
             ->where('type_id', LikeType::DISLIKE);
     }
 
     /**
-     * Model likesCount attribute.
+     * Model likersCount attribute.
      *
      * @return int
      */
-    public function getLikesCountAttribute()
+    public function getLikersCountAttribute()
     {
-        return $this->likesCounter ? $this->likesCounter->count : 0;
+        return $this->likersCounter ? $this->likersCounter->count : 0;
     }
 
     /**
-     * Model dislikesCount attribute.
+     * Model dislikersCount attribute.
      *
      * @return int
      */
-    public function getDislikesCountAttribute()
+    public function getDislikersCountAttribute()
     {
-        return $this->dislikesCounter ? $this->dislikesCounter->count : 0;
+        return $this->dislikersCounter ? $this->dislikersCounter->count : 0;
     }
 
     /**
@@ -131,9 +131,9 @@ trait HasLikes
      *
      * @return int
      */
-    public function getLikesDiffDislikesCountAttribute()
+    public function getLikersDiffDislikersCountAttribute()
     {
-        return $this->likesCount - $this->dislikesCount;
+        return $this->likersCount - $this->dislikersCount;
     }
 
     /**

--- a/src/Traits/HasLikes.php
+++ b/src/Traits/HasLikes.php
@@ -11,11 +11,11 @@
 
 namespace Cog\Likeable\Traits;
 
-use Cog\Likeable\Contracts\Like as LikeContract;
-use Cog\Likeable\Contracts\LikeableService as LikeableServiceContract;
-use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
 use Cog\Likeable\Enums\LikeType;
 use Cog\Likeable\Observers\ModelObserver;
+use Cog\Likeable\Contracts\Like as LikeContract;
+use Cog\Likeable\Contracts\LikersCounter as LikersCounterContract;
+use Cog\Likeable\Contracts\LikeableService as LikeableServiceContract;
 
 /**
  * Class HasLikes.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,11 +11,11 @@
 
 namespace Cog\Likeable\Tests;
 
-use Cog\Likeable\Tests\Stubs\Models\EntityWithMorphMap;
-use File;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Mockery;
+use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Cog\Likeable\Tests\Stubs\Models\EntityWithMorphMap;
 
 /**
  * Class TestCase.

--- a/tests/migrations/2016_09_02_173301_create_article_table.php
+++ b/tests/migrations/2016_09_02_173301_create_article_table.php
@@ -9,8 +9,9 @@
  * file that was distributed with this source code.
  */
 
-use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 /**
  * Class CreateArticleTable.

--- a/tests/migrations/2016_09_02_173301_create_article_table.php
+++ b/tests/migrations/2016_09_02_173301_create_article_table.php
@@ -17,6 +17,11 @@ use Illuminate\Database\Schema\Blueprint;
  */
 class CreateArticleTable extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('article', function (Blueprint $table) {
@@ -26,8 +31,13 @@ class CreateArticleTable extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
-        Schema::drop('article');
+        Schema::dropIfExists('article');
     }
 }

--- a/tests/migrations/2016_09_02_173301_create_entity_table.php
+++ b/tests/migrations/2016_09_02_173301_create_entity_table.php
@@ -9,8 +9,9 @@
  * file that was distributed with this source code.
  */
 
-use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 /**
  * Class CreateEntityTable.

--- a/tests/migrations/2016_09_02_173301_create_entity_table.php
+++ b/tests/migrations/2016_09_02_173301_create_entity_table.php
@@ -17,6 +17,11 @@ use Illuminate\Database\Schema\Blueprint;
  */
 class CreateEntityTable extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('entity', function (Blueprint $table) {
@@ -26,8 +31,13 @@ class CreateEntityTable extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
-        Schema::drop('entity');
+        Schema::dropIfExists('entity');
     }
 }

--- a/tests/migrations/2016_09_02_173301_create_entity_with_morph_map_table.php
+++ b/tests/migrations/2016_09_02_173301_create_entity_with_morph_map_table.php
@@ -9,8 +9,9 @@
  * file that was distributed with this source code.
  */
 
-use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 /**
  * Class CreateEntityWithMorphMapTable.

--- a/tests/migrations/2016_09_02_173301_create_entity_with_morph_map_table.php
+++ b/tests/migrations/2016_09_02_173301_create_entity_with_morph_map_table.php
@@ -17,6 +17,11 @@ use Illuminate\Database\Schema\Blueprint;
  */
 class CreateEntityWithMorphMapTable extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('entity_with_morph_map', function (Blueprint $table) {
@@ -26,8 +31,13 @@ class CreateEntityWithMorphMapTable extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
-        Schema::drop('entity_with_morph_map');
+        Schema::dropIfExists('entity_with_morph_map');
     }
 }

--- a/tests/migrations/2016_09_02_173301_create_user_table.php
+++ b/tests/migrations/2016_09_02_173301_create_user_table.php
@@ -9,8 +9,9 @@
  * file that was distributed with this source code.
  */
 
-use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 /**
  * Class CreateUserTable.

--- a/tests/migrations/2016_09_02_173301_create_user_table.php
+++ b/tests/migrations/2016_09_02_173301_create_user_table.php
@@ -17,6 +17,11 @@ use Illuminate\Database\Schema\Blueprint;
  */
 class CreateUserTable extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('user', function (Blueprint $table) {
@@ -26,8 +31,13 @@ class CreateUserTable extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
     public function down()
     {
-        Schema::drop('user');
+        Schema::dropIfExists('user');
     }
 }

--- a/tests/stubs/Models/Article.php
+++ b/tests/stubs/Models/Article.php
@@ -11,9 +11,9 @@
 
 namespace Cog\Likeable\Tests\Stubs\Models;
 
-use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 use Cog\Likeable\Traits\HasLikes;
 use Illuminate\Database\Eloquent\Model;
+use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 
 /**
  * Class Article.

--- a/tests/stubs/Models/Entity.php
+++ b/tests/stubs/Models/Entity.php
@@ -11,9 +11,9 @@
 
 namespace Cog\Likeable\Tests\Stubs\Models;
 
-use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 use Cog\Likeable\Traits\HasLikes;
 use Illuminate\Database\Eloquent\Model;
+use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 
 /**
  * Class Entity.

--- a/tests/stubs/Models/EntityWithMorphMap.php
+++ b/tests/stubs/Models/EntityWithMorphMap.php
@@ -11,9 +11,9 @@
 
 namespace Cog\Likeable\Tests\Stubs\Models;
 
-use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 use Cog\Likeable\Traits\HasLikes;
 use Illuminate\Database\Eloquent\Model;
+use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 
 /**
  * Class EntityWithMorphMap.

--- a/tests/unit/Console/LikeableRecountCommandTest.php
+++ b/tests/unit/Console/LikeableRecountCommandTest.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Likeable\Tests\Unit\Observers;
 
-use Cog\Likeable\Models\LikeCounter;
+use Cog\Likeable\Models\LikersCounter;
 use Cog\Likeable\Tests\Stubs\Models\Article;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
 use Cog\Likeable\Tests\Stubs\Models\EntityWithMorphMap;
@@ -56,7 +56,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->like(4);
         $article->like(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -68,12 +68,12 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(3, $likeCounter);
-        $this->assertEquals(0, $entity1->dislikesCount);
-        $this->assertEquals(3, $entity1->likesCount);
-        $this->assertEquals(4, $entity2->likesCount);
-        $this->assertEquals(1, $article->likesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(3, $likersCounter);
+        $this->assertEquals(0, $entity1->dislikersCount);
+        $this->assertEquals(3, $entity1->likersCount);
+        $this->assertEquals(4, $entity2->likersCount);
+        $this->assertEquals(1, $article->likersCount);
     }
 
     /** @test */
@@ -91,7 +91,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->like(3);
         $entity2->like(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -104,11 +104,11 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(2, $likeCounter);
-        $this->assertEquals(0, $entity1->dislikesCount);
-        $this->assertEquals(3, $entity1->likesCount);
-        $this->assertEquals(4, $entity2->likesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(2, $likersCounter);
+        $this->assertEquals(0, $entity1->dislikersCount);
+        $this->assertEquals(3, $entity1->likersCount);
+        $this->assertEquals(4, $entity2->likersCount);
     }
 
     /** @test */
@@ -126,7 +126,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->like(3);
         $entity2->like(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -139,11 +139,11 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(2, $likeCounter);
-        $this->assertEquals(0, $entity1->dislikesCount);
-        $this->assertEquals(3, $entity1->likesCount);
-        $this->assertEquals(4, $entity2->likesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(2, $likersCounter);
+        $this->assertEquals(0, $entity1->dislikersCount);
+        $this->assertEquals(3, $entity1->likersCount);
+        $this->assertEquals(4, $entity2->likersCount);
     }
 
     /** @test */
@@ -161,7 +161,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->like(3);
         $entity2->like(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -174,11 +174,11 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(2, $likeCounter);
-        $this->assertEquals(0, $entity1->dislikesCount);
-        $this->assertEquals(3, $entity1->likesCount);
-        $this->assertEquals(4, $entity2->likesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(2, $likersCounter);
+        $this->assertEquals(0, $entity1->dislikersCount);
+        $this->assertEquals(3, $entity1->likersCount);
+        $this->assertEquals(4, $entity2->likersCount);
     }
 
     /* Dislikes */
@@ -200,7 +200,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->dislike(4);
         $article->dislike(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -212,12 +212,12 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(3, $likeCounter);
-        $this->assertEquals(0, $entity1->likesCount);
-        $this->assertEquals(3, $entity1->dislikesCount);
-        $this->assertEquals(4, $entity2->dislikesCount);
-        $this->assertEquals(1, $article->dislikesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(3, $likersCounter);
+        $this->assertEquals(0, $entity1->likersCount);
+        $this->assertEquals(3, $entity1->dislikersCount);
+        $this->assertEquals(4, $entity2->dislikersCount);
+        $this->assertEquals(1, $article->dislikersCount);
     }
 
     /** @test */
@@ -235,7 +235,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->dislike(3);
         $entity2->dislike(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -248,11 +248,11 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(2, $likeCounter);
-        $this->assertEquals(0, $entity1->likesCount);
-        $this->assertEquals(3, $entity1->dislikesCount);
-        $this->assertEquals(4, $entity2->dislikesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(2, $likersCounter);
+        $this->assertEquals(0, $entity1->likersCount);
+        $this->assertEquals(3, $entity1->dislikersCount);
+        $this->assertEquals(4, $entity2->dislikersCount);
     }
 
     /** @test */
@@ -270,7 +270,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->dislike(3);
         $entity2->dislike(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -283,11 +283,11 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(2, $likeCounter);
-        $this->assertEquals(0, $entity1->likesCount);
-        $this->assertEquals(3, $entity1->dislikesCount);
-        $this->assertEquals(4, $entity2->dislikesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(2, $likersCounter);
+        $this->assertEquals(0, $entity1->likersCount);
+        $this->assertEquals(3, $entity1->dislikersCount);
+        $this->assertEquals(4, $entity2->dislikersCount);
     }
 
     /** @test */
@@ -305,7 +305,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->dislike(3);
         $entity2->dislike(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -318,11 +318,11 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(2, $likeCounter);
-        $this->assertEquals(0, $entity1->likesCount);
-        $this->assertEquals(3, $entity1->dislikesCount);
-        $this->assertEquals(4, $entity2->dislikesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(2, $likersCounter);
+        $this->assertEquals(0, $entity1->likersCount);
+        $this->assertEquals(3, $entity1->dislikersCount);
+        $this->assertEquals(4, $entity2->dislikersCount);
     }
 
     /* Likes & Dislikes */
@@ -343,7 +343,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->dislike(4);
         $article->dislike(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -354,13 +354,13 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(5, $likeCounter);
-        $this->assertEquals(2, $entity1->likesCount);
-        $this->assertEquals(1, $entity1->dislikesCount);
-        $this->assertEquals(2, $entity2->likesCount);
-        $this->assertEquals(2, $entity2->dislikesCount);
-        $this->assertEquals(1, $article->dislikesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(5, $likersCounter);
+        $this->assertEquals(2, $entity1->likersCount);
+        $this->assertEquals(1, $entity1->dislikersCount);
+        $this->assertEquals(2, $entity2->likersCount);
+        $this->assertEquals(2, $entity2->dislikersCount);
+        $this->assertEquals(1, $article->dislikersCount);
     }
 
     /** @test */
@@ -377,7 +377,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->dislike(3);
         $entity2->dislike(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -389,12 +389,12 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(4, $likeCounter);
-        $this->assertEquals(2, $entity1->likesCount);
-        $this->assertEquals(1, $entity1->dislikesCount);
-        $this->assertEquals(2, $entity2->likesCount);
-        $this->assertEquals(2, $entity2->dislikesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(4, $likersCounter);
+        $this->assertEquals(2, $entity1->likersCount);
+        $this->assertEquals(1, $entity1->dislikersCount);
+        $this->assertEquals(2, $entity2->likersCount);
+        $this->assertEquals(2, $entity2->dislikersCount);
     }
 
     /** @test */
@@ -411,7 +411,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->dislike(3);
         $entity2->dislike(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -423,12 +423,12 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(4, $likeCounter);
-        $this->assertEquals(2, $entity1->likesCount);
-        $this->assertEquals(1, $entity1->dislikesCount);
-        $this->assertEquals(2, $entity2->likesCount);
-        $this->assertEquals(2, $entity2->dislikesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(4, $likersCounter);
+        $this->assertEquals(2, $entity1->likersCount);
+        $this->assertEquals(1, $entity1->dislikersCount);
+        $this->assertEquals(2, $entity2->likersCount);
+        $this->assertEquals(2, $entity2->dislikersCount);
     }
 
     /** @test */
@@ -445,7 +445,7 @@ class LikeableRecountCommandTest extends TestCase
         $entity2->dislike(3);
         $entity2->dislike(4);
 
-        LikeCounter::truncate();
+        LikersCounter::truncate();
 
         $status = $this->kernel->handle(
             $input = new ArrayInput([
@@ -457,12 +457,12 @@ class LikeableRecountCommandTest extends TestCase
 
         $this->assertEquals(0, $status);
 
-        $likeCounter = LikeCounter::all();
-        $this->assertCount(4, $likeCounter);
-        $this->assertEquals(2, $entity1->likesCount);
-        $this->assertEquals(1, $entity1->dislikesCount);
-        $this->assertEquals(2, $entity2->likesCount);
-        $this->assertEquals(2, $entity2->dislikesCount);
+        $likersCounter = LikersCounter::all();
+        $this->assertCount(4, $likersCounter);
+        $this->assertEquals(2, $entity1->likersCount);
+        $this->assertEquals(1, $entity1->dislikersCount);
+        $this->assertEquals(2, $entity2->likersCount);
+        $this->assertEquals(2, $entity2->dislikersCount);
     }
 
     /* Exceptions */
@@ -499,6 +499,6 @@ class LikeableRecountCommandTest extends TestCase
 
     public function it_deletes_records_before_recount()
     {
-        // :TODO: Mock `removeLikeCountersOfType` method call
+        // :TODO: Mock `removeLikersCountersOfType` method call
     }
 }

--- a/tests/unit/Console/LikeableRecountCommandTest.php
+++ b/tests/unit/Console/LikeableRecountCommandTest.php
@@ -11,15 +11,15 @@
 
 namespace Cog\Likeable\Tests\Unit\Observers;
 
-use Cog\Likeable\Models\LikersCounter;
-use Cog\Likeable\Tests\Stubs\Models\Article;
-use Cog\Likeable\Tests\Stubs\Models\Entity;
-use Cog\Likeable\Tests\Stubs\Models\EntityWithMorphMap;
-use Cog\Likeable\Tests\Stubs\Models\User;
 use Cog\Likeable\Tests\TestCase;
+use Cog\Likeable\Models\LikersCounter;
 use Illuminate\Contracts\Console\Kernel;
+use Cog\Likeable\Tests\Stubs\Models\User;
+use Cog\Likeable\Tests\Stubs\Models\Entity;
+use Cog\Likeable\Tests\Stubs\Models\Article;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Cog\Likeable\Tests\Stubs\Models\EntityWithMorphMap;
 
 /**
  * Class LikeableRecountCommandTest.

--- a/tests/unit/Events/ModelWasDislikedTest.php
+++ b/tests/unit/Events/ModelWasDislikedTest.php
@@ -11,9 +11,9 @@
 
 namespace Cog\Likeable\Tests\Unit\Events;
 
+use Cog\Likeable\Tests\TestCase;
 use Cog\Likeable\Events\ModelWasDisliked;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
-use Cog\Likeable\Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**

--- a/tests/unit/Events/ModelWasLikedTest.php
+++ b/tests/unit/Events/ModelWasLikedTest.php
@@ -11,9 +11,9 @@
 
 namespace Cog\Likeable\Tests\Unit\Events;
 
+use Cog\Likeable\Tests\TestCase;
 use Cog\Likeable\Events\ModelWasLiked;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
-use Cog\Likeable\Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**

--- a/tests/unit/Events/ModelWasUndislikedTest.php
+++ b/tests/unit/Events/ModelWasUndislikedTest.php
@@ -11,9 +11,9 @@
 
 namespace Cog\Likeable\Tests\Unit\Events;
 
+use Cog\Likeable\Tests\TestCase;
 use Cog\Likeable\Events\ModelWasUndisliked;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
-use Cog\Likeable\Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**

--- a/tests/unit/Events/ModelWasUnlikedTest.php
+++ b/tests/unit/Events/ModelWasUnlikedTest.php
@@ -11,9 +11,9 @@
 
 namespace Cog\Likeable\Tests\Unit\Events;
 
+use Cog\Likeable\Tests\TestCase;
 use Cog\Likeable\Events\ModelWasUnliked;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
-use Cog\Likeable\Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**

--- a/tests/unit/Exceptions/LikerNotDefinedExceptionTest.php
+++ b/tests/unit/Exceptions/LikerNotDefinedExceptionTest.php
@@ -11,10 +11,10 @@
 
 namespace Cog\Likeable\Tests\Unit;
 
-use Cog\Likeable\Exceptions\LikerNotDefinedException;
-use Cog\Likeable\Tests\Stubs\Models\Entity;
-use Cog\Likeable\Tests\Stubs\Models\User;
 use Cog\Likeable\Tests\TestCase;
+use Cog\Likeable\Tests\Stubs\Models\User;
+use Cog\Likeable\Tests\Stubs\Models\Entity;
+use Cog\Likeable\Exceptions\LikerNotDefinedException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**

--- a/tests/unit/Models/LikersCounterTest.php
+++ b/tests/unit/Models/LikersCounterTest.php
@@ -11,20 +11,20 @@
 
 namespace Cog\Likeable\Tests\Unit\Models;
 
-use Cog\Likeable\Models\LikeCounter;
+use Cog\Likeable\Models\LikersCounter;
 use Cog\Likeable\Tests\TestCase;
 
 /**
- * Class LikeCounterTest.
+ * Class LikersCounterTest.
  *
  * @package Cog\Likeable\Tests\Unit\Models
  */
-class LikeCounterTest extends TestCase
+class LikersCounterTest extends TestCase
 {
     /** @test */
     public function it_can_fill_count()
     {
-        $counter = new LikeCounter([
+        $counter = new LikersCounter([
             'count' => 4,
         ]);
 
@@ -34,7 +34,7 @@ class LikeCounterTest extends TestCase
     /** @test */
     public function it_can_cast_count()
     {
-        $like = new LikeCounter([
+        $like = new LikersCounter([
             'count' => '4',
         ]);
 
@@ -44,7 +44,7 @@ class LikeCounterTest extends TestCase
     /** @test */
     public function it_can_fill_type_id()
     {
-        $counter = new LikeCounter([
+        $counter = new LikersCounter([
             'type_id' => 2,
         ]);
 

--- a/tests/unit/Models/LikersCounterTest.php
+++ b/tests/unit/Models/LikersCounterTest.php
@@ -11,8 +11,8 @@
 
 namespace Cog\Likeable\Tests\Unit\Models;
 
-use Cog\Likeable\Models\LikersCounter;
 use Cog\Likeable\Tests\TestCase;
+use Cog\Likeable\Models\LikersCounter;
 
 /**
  * Class LikersCounterTest.

--- a/tests/unit/Observers/ModelObserverTest.php
+++ b/tests/unit/Observers/ModelObserverTest.php
@@ -13,7 +13,7 @@ namespace Cog\Likeable\Tests\Unit\Observers;
 
 use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 use Cog\Likeable\Models\Like;
-use Cog\Likeable\Models\LikeCounter;
+use Cog\Likeable\Models\LikersCounter;
 use Cog\Likeable\Observers\ModelObserver;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
 use Cog\Likeable\Tests\TestCase;
@@ -67,9 +67,9 @@ class ModelObserverTest extends TestCase
         $entity1->delete();
 
         $entity1Likes = Like::whereIn('id', $entity1Likes->pluck('id'))->get();
-        $likeCounter = LikeCounter::all();
+        $likersCounter = LikersCounter::all();
 
         $this->assertCount(0, $entity1Likes);
-        $this->assertCount(1, $likeCounter);
+        $this->assertCount(1, $likersCounter);
     }
 }

--- a/tests/unit/Observers/ModelObserverTest.php
+++ b/tests/unit/Observers/ModelObserverTest.php
@@ -11,14 +11,14 @@
 
 namespace Cog\Likeable\Tests\Unit\Observers;
 
-use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
+use Mockery;
 use Cog\Likeable\Models\Like;
+use Cog\Likeable\Tests\TestCase;
 use Cog\Likeable\Models\LikersCounter;
 use Cog\Likeable\Observers\ModelObserver;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
-use Cog\Likeable\Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Mockery;
+use Cog\Likeable\Contracts\HasLikes as HasLikesContract;
 
 /**
  * Class ModelObserverTest.

--- a/tests/unit/Relations/LikeTest.php
+++ b/tests/unit/Relations/LikeTest.php
@@ -12,8 +12,8 @@
 namespace Cog\Likeable\Tests\Unit\Relations;
 
 use Cog\Likeable\Models\Like;
-use Cog\Likeable\Tests\Stubs\Models\Entity;
 use Cog\Likeable\Tests\TestCase;
+use Cog\Likeable\Tests\Stubs\Models\Entity;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**

--- a/tests/unit/Relations/LikersCounterTest.php
+++ b/tests/unit/Relations/LikersCounterTest.php
@@ -11,9 +11,9 @@
 
 namespace Cog\Likeable\Tests\Unit\Relations;
 
+use Cog\Likeable\Tests\TestCase;
 use Cog\Likeable\Models\LikersCounter;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
-use Cog\Likeable\Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**

--- a/tests/unit/Relations/LikersCounterTest.php
+++ b/tests/unit/Relations/LikersCounterTest.php
@@ -11,17 +11,17 @@
 
 namespace Cog\Likeable\Tests\Unit\Relations;
 
-use Cog\Likeable\Models\LikeCounter;
+use Cog\Likeable\Models\LikersCounter;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
 use Cog\Likeable\Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**
- * Class LikeCounterTest.
+ * Class LikersCounterTest.
  *
  * @package Cog\Likeable\Tests\Unit\Relations
  */
-class LikeCounterTest extends TestCase
+class LikersCounterTest extends TestCase
 {
     use DatabaseTransactions;
 
@@ -32,6 +32,6 @@ class LikeCounterTest extends TestCase
 
         $entity->like(1);
 
-        $this->assertInstanceOf(Entity::class, LikeCounter::first()->likeable);
+        $this->assertInstanceOf(Entity::class, LikersCounter::first()->likeable);
     }
 }

--- a/tests/unit/Services/LikeableServiceTest.php
+++ b/tests/unit/Services/LikeableServiceTest.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Likeable\Tests\Unit\Services;
 
-use Cog\Likeable\Models\LikeCounter;
+use Cog\Likeable\Models\LikersCounter;
 use Cog\Likeable\Services\LikeableService as LikeableServiceContract;
 use Cog\Likeable\Tests\Stubs\Models\Article;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
@@ -44,10 +44,10 @@ class LikeableServiceTest extends TestCase
         $entity->like(1);
         $entity->like(2);
 
-        $service->decrementLikesCount($entity);
-        $service->decrementLikesCount($entity);
+        $service->decrementLikersCount($entity);
+        $service->decrementLikersCount($entity);
 
-        $this->assertEquals(0, $entity->likesCount);
+        $this->assertEquals(0, $entity->likersCount);
     }
 
     /** @test */
@@ -56,9 +56,9 @@ class LikeableServiceTest extends TestCase
         $service = $this->app->make(LikeableServiceContract::class);
         $entity = factory(Entity::class)->create();
 
-        $service->decrementLikesCount($entity);
+        $service->decrementLikersCount($entity);
 
-        $this->assertEquals(0, $entity->likesCount);
+        $this->assertEquals(0, $entity->likersCount);
     }
 
     /** @test */
@@ -67,10 +67,10 @@ class LikeableServiceTest extends TestCase
         $service = $this->app->make(LikeableServiceContract::class);
         $entity = factory(Entity::class)->create();
 
-        $service->incrementLikesCount($entity);
-        $service->incrementLikesCount($entity);
+        $service->incrementLikersCount($entity);
+        $service->incrementLikersCount($entity);
 
-        $this->assertEquals(2, $entity->likesCount);
+        $this->assertEquals(2, $entity->likersCount);
     }
 
     /** @test */
@@ -84,11 +84,11 @@ class LikeableServiceTest extends TestCase
         $entity2->like(2);
         $article->like(1);
 
-        $service->removeLikeCountersOfType(Entity::class, 'like');
+        $service->removeLikersCountersOfType(Entity::class, 'like');
 
-        $likeCounters = LikeCounter::all();
+        $likersCounters = LikersCounter::all();
 
-        $this->assertCount(1, $likeCounters);
+        $this->assertCount(1, $likersCounters);
     }
 
     /** @test */
@@ -102,11 +102,11 @@ class LikeableServiceTest extends TestCase
         $entity2->like(2);
         $article->like(1);
 
-        $service->removeLikeCountersOfType('entity-with-morph-map', 'like');
+        $service->removeLikersCountersOfType('entity-with-morph-map', 'like');
 
-        $likeCounters = LikeCounter::all();
+        $likersCounters = LikersCounter::all();
 
-        $this->assertCount(1, $likeCounters);
+        $this->assertCount(1, $likersCounters);
     }
 
     /** @test */
@@ -120,11 +120,11 @@ class LikeableServiceTest extends TestCase
         $entity2->like(2);
         $article->like(1);
 
-        $service->removeLikeCountersOfType(EntityWithMorphMap::class, 'like');
+        $service->removeLikersCountersOfType(EntityWithMorphMap::class, 'like');
 
-        $likeCounters = LikeCounter::all();
+        $likersCounters = LikersCounter::all();
 
-        $this->assertCount(1, $likeCounters);
+        $this->assertCount(1, $likersCounters);
     }
 
     /** @test */
@@ -154,7 +154,7 @@ class LikeableServiceTest extends TestCase
 
         $this->assertCount(1, $entity->likesAndDislikes);
         $this->assertCount(1, $entity->dislikes);
-        $this->assertEquals(1, $entity->dislikesCount);
+        $this->assertEquals(1, $entity->dislikersCount);
     }
 
     /** @test */
@@ -167,6 +167,6 @@ class LikeableServiceTest extends TestCase
 
         $this->assertCount(1, $entity->likesAndDislikes);
         $this->assertCount(1, $entity->likes);
-        $this->assertEquals(1, $entity->likesCount);
+        $this->assertEquals(1, $entity->likersCount);
     }
 }

--- a/tests/unit/Services/LikeableServiceTest.php
+++ b/tests/unit/Services/LikeableServiceTest.php
@@ -11,13 +11,13 @@
 
 namespace Cog\Likeable\Tests\Unit\Services;
 
-use Cog\Likeable\Models\LikersCounter;
-use Cog\Likeable\Services\LikeableService as LikeableServiceContract;
-use Cog\Likeable\Tests\Stubs\Models\Article;
-use Cog\Likeable\Tests\Stubs\Models\Entity;
-use Cog\Likeable\Tests\Stubs\Models\EntityWithMorphMap;
 use Cog\Likeable\Tests\TestCase;
+use Cog\Likeable\Models\LikersCounter;
+use Cog\Likeable\Tests\Stubs\Models\Entity;
+use Cog\Likeable\Tests\Stubs\Models\Article;
+use Cog\Likeable\Tests\Stubs\Models\EntityWithMorphMap;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Cog\Likeable\Services\LikeableService as LikeableServiceContract;
 
 /**
  * Class LikeableServiceTest.

--- a/tests/unit/Traits/HasLikesTest.php
+++ b/tests/unit/Traits/HasLikesTest.php
@@ -38,7 +38,7 @@ class HasLikesTest extends TestCase
 
         $entity->like();
 
-        $this->assertEquals(1, $entity->likesCount);
+        $this->assertEquals(1, $entity->likersCount);
         $this->assertEquals($user->id, $entity->likes->first()->user_id);
     }
 
@@ -53,7 +53,7 @@ class HasLikesTest extends TestCase
 
         $entity->like($user2->id);
 
-        $this->assertEquals(1, $entity->likesCount);
+        $this->assertEquals(1, $entity->likersCount);
         $this->assertEquals($user2->id, $entity->likes->first()->user_id);
     }
 
@@ -67,7 +67,7 @@ class HasLikesTest extends TestCase
         $entity->like(3);
         $entity->like(4);
 
-        $this->assertEquals(4, $entity->likesCount);
+        $this->assertEquals(4, $entity->likersCount);
     }
 
     /** @test */
@@ -78,7 +78,7 @@ class HasLikesTest extends TestCase
         $entity->like(1);
         $entity->like(1);
 
-        $this->assertEquals(1, $entity->likesCount);
+        $this->assertEquals(1, $entity->likersCount);
     }
 
     /** @test */
@@ -89,7 +89,7 @@ class HasLikesTest extends TestCase
 
         $entity->unlike(1);
 
-        $this->assertEquals(0, $entity->likesCount);
+        $this->assertEquals(0, $entity->likersCount);
     }
 
     /** @test */
@@ -100,7 +100,7 @@ class HasLikesTest extends TestCase
 
         $entity->unlike(2);
 
-        $this->assertEquals(1, $entity->likesCount);
+        $this->assertEquals(1, $entity->likersCount);
     }
 
     /** @test */
@@ -113,7 +113,7 @@ class HasLikesTest extends TestCase
 
         $entity->likeToggle();
 
-        $this->assertEquals(1, $entity->likesCount);
+        $this->assertEquals(1, $entity->likersCount);
         $this->assertEquals($user->id, $entity->likes->first()->user_id);
     }
 
@@ -128,7 +128,7 @@ class HasLikesTest extends TestCase
 
         $entity->likeToggle();
 
-        $this->assertEquals(0, $entity->likesCount);
+        $this->assertEquals(0, $entity->likersCount);
     }
 
     /** @test */
@@ -137,7 +137,7 @@ class HasLikesTest extends TestCase
         $entity = factory(Entity::class)->create();
 
         $entity->likeToggle(1);
-        $this->assertEquals(1, $entity->likesCount);
+        $this->assertEquals(1, $entity->likersCount);
     }
 
     /** @test */
@@ -147,7 +147,7 @@ class HasLikesTest extends TestCase
         $entity->like(1);
 
         $entity->likeToggle(1);
-        $this->assertEquals(0, $entity->likesCount);
+        $this->assertEquals(0, $entity->likersCount);
     }
 
     /** @test */
@@ -222,7 +222,7 @@ class HasLikesTest extends TestCase
 
         $entity->dislike();
 
-        $this->assertEquals(1, $entity->dislikesCount);
+        $this->assertEquals(1, $entity->dislikersCount);
         $this->assertEquals($user->id, $entity->dislikes->first()->user_id);
     }
 
@@ -237,7 +237,7 @@ class HasLikesTest extends TestCase
 
         $entity->dislike($user2->id);
 
-        $this->assertEquals(1, $entity->dislikesCount);
+        $this->assertEquals(1, $entity->dislikersCount);
         $this->assertEquals($user2->id, $entity->dislikes->first()->user_id);
     }
 
@@ -251,7 +251,7 @@ class HasLikesTest extends TestCase
         $entity->dislike(3);
         $entity->dislike(4);
 
-        $this->assertEquals(4, $entity->dislikesCount);
+        $this->assertEquals(4, $entity->dislikersCount);
     }
 
     /** @test */
@@ -262,7 +262,7 @@ class HasLikesTest extends TestCase
         $entity->dislike(1);
         $entity->dislike(1);
 
-        $this->assertEquals(1, $entity->dislikesCount);
+        $this->assertEquals(1, $entity->dislikersCount);
     }
 
     /** @test */
@@ -273,7 +273,7 @@ class HasLikesTest extends TestCase
 
         $entity->undislike(1);
 
-        $this->assertEquals(0, $entity->dislikesCount);
+        $this->assertEquals(0, $entity->dislikersCount);
     }
 
     /** @test */
@@ -284,7 +284,7 @@ class HasLikesTest extends TestCase
 
         $entity->undislike(2);
 
-        $this->assertEquals(1, $entity->dislikesCount);
+        $this->assertEquals(1, $entity->dislikersCount);
     }
 
     /** @test */
@@ -297,7 +297,7 @@ class HasLikesTest extends TestCase
 
         $entity->dislikeToggle();
 
-        $this->assertEquals(1, $entity->dislikesCount);
+        $this->assertEquals(1, $entity->dislikersCount);
         $this->assertEquals($user->id, $entity->dislikes->first()->user_id);
     }
 
@@ -312,7 +312,7 @@ class HasLikesTest extends TestCase
 
         $entity->dislikeToggle();
 
-        $this->assertEquals(0, $entity->dislikesCount);
+        $this->assertEquals(0, $entity->dislikersCount);
     }
 
     /** @test */
@@ -321,7 +321,7 @@ class HasLikesTest extends TestCase
         $entity = factory(Entity::class)->create();
 
         $entity->dislikeToggle(1);
-        $this->assertEquals(1, $entity->dislikesCount);
+        $this->assertEquals(1, $entity->dislikersCount);
     }
 
     /** @test */
@@ -331,7 +331,7 @@ class HasLikesTest extends TestCase
         $entity->dislike(1);
 
         $entity->dislikeToggle(1);
-        $this->assertEquals(0, $entity->dislikesCount);
+        $this->assertEquals(0, $entity->dislikersCount);
     }
 
     /** @test */
@@ -439,6 +439,6 @@ class HasLikesTest extends TestCase
         $entity->dislike(2);
         $entity->dislike(3);
 
-        $this->assertEquals(-1, $entity->likesDiffDislikesCount);
+        $this->assertEquals(-1, $entity->likersDiffDislikersCount);
     }
 }

--- a/tests/unit/Traits/HasLikesTest.php
+++ b/tests/unit/Traits/HasLikesTest.php
@@ -11,10 +11,10 @@
 
 namespace Cog\Likeable\Tests\Unit;
 
-use Cog\Likeable\Contracts\Like as LikeContract;
-use Cog\Likeable\Tests\Stubs\Models\Entity;
-use Cog\Likeable\Tests\Stubs\Models\User;
 use Cog\Likeable\Tests\TestCase;
+use Cog\Likeable\Tests\Stubs\Models\User;
+use Cog\Likeable\Tests\Stubs\Models\Entity;
+use Cog\Likeable\Contracts\Like as LikeContract;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 /**


### PR DESCRIPTION
Synchronizing Likeable package API with other CyberCog packages. And there could be requirement to get count of likes which user has been set. And adding additional `likes count` methods and attributes will add naming collision and could add additional developer confusion.

Package still working the same way, only counter table, class name and all it's related methods has been renamed.

Change is pretty simple. Now you are getting counter of likers of the model instead of the counter of likes. And because likers are unique for the model - application logic is the same.
