### PR TITLE
Fix bootObservers for custom Like model

### DIFF
--- a/src/Providers/LikeableServiceProvider.php
+++ b/src/Providers/LikeableServiceProvider.php
@@ -63,6 +63,7 @@ class LikeableServiceProvider extends ServiceProvider
      */
     protected function bootObservers()
     {
-        Like::observe(new LikeObserver());
+        $class = $this->app->make(LikeContract::class);
+        $class::observe(new LikeObserver());
     }
 }


### PR DESCRIPTION
When overriding the default `Like` model with your own, the standard service provider incorrectly boots the observers on the original `Cog\Likeable\Models\Like` class. This manifests itself as the counters not updating correctly when liking/disliking, events not working etc.

This should perhaps be documented so it is clear you also have to add the observer into your own `boot` method in your service provider (in which case you don't really need the default service provider at all), or alternatively the `observe` call could be based on the alias in the app container (this PR).

Cheers for a great package :)