### PR TITLE
userLikes feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,21 @@ $article->likesAndDislikes();
 $article->likesAndDislikes;
 ```
 
+#### Logged in User iterable Likes and Dislikes
+
+##### Iterate through likes of the current logged in user
+```php
+$article->userLikes;
+```
+##### Iterate through dislikes of the current logged in user
+```php
+$article->userDislikes;
+```
+##### Iterate through likes and dislikes of the current logged in user
+```php
+$article->userLikesAndDislikes;
+```
+
 ### Scopes
 
 ##### Find all articles liked by user

--- a/src/Traits/Likeable.php
+++ b/src/Traits/Likeable.php
@@ -114,7 +114,7 @@ trait Likeable
     }
 
     /**
-     * Collection of dislikes on this record by the logged in user.
+     * Collection of likes and dislikes on this record by the logged in user.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */

--- a/src/Traits/Likeable.php
+++ b/src/Traits/Likeable.php
@@ -88,6 +88,46 @@ trait Likeable
     }
 
     /**
+    * Collection of likes on this record by the logged in user.
+    *
+    * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+    */
+    public function userLikes()
+    {
+        return $this->likesAndDislikes()->where([
+            'type_id' => LikeType::LIKE,
+            'user_id' => auth()->id()
+        ]);
+    }
+
+
+    /**
+    * Collection of dislikes on this record by the logged in user.
+    *
+    * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+    */
+    public function userDislikes()
+    {
+        return $this->likesAndDislikes()->where([
+            'type_id' => LikeType::DISLIKE,
+            'user_id' => auth()->id()
+        ]);
+    }
+
+
+    /**
+    * Collection of dislikes on this record by the logged in user.
+    *
+    * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+    */
+    public function userLikesAndDislikes()
+    {
+        return $this->likesAndDislikes()->where([
+            'user_id' => auth()->id()
+        ]);
+    }
+
+    /**
      * Fetch users who liked entity.
      *
      * @return \Illuminate\Support\Collection

--- a/src/Traits/Likeable.php
+++ b/src/Traits/Likeable.php
@@ -88,10 +88,10 @@ trait Likeable
     }
 
     /**
-    * Collection of likes on this record by the logged in user.
-    *
-    * @return \Illuminate\Database\Eloquent\Relations\MorphMany
-    */
+     * Collection of likes on this record by the logged in user.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
     public function userLikes()
     {
         return $this->likesAndDislikes()->where([
@@ -101,10 +101,10 @@ trait Likeable
     }
 
     /**
-    * Collection of dislikes on this record by the logged in user.
-    *
-    * @return \Illuminate\Database\Eloquent\Relations\MorphMany
-    */
+     * Collection of dislikes on this record by the logged in user.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
     public function userDislikes()
     {
         return $this->likesAndDislikes()->where([
@@ -114,10 +114,10 @@ trait Likeable
     }
 
     /**
-    * Collection of dislikes on this record by the logged in user.
-    *
-    * @return \Illuminate\Database\Eloquent\Relations\MorphMany
-    */
+     * Collection of dislikes on this record by the logged in user.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
     public function userLikesAndDislikes()
     {
         return $this->likesAndDislikes()->where([

--- a/src/Traits/Likeable.php
+++ b/src/Traits/Likeable.php
@@ -96,10 +96,9 @@ trait Likeable
     {
         return $this->likesAndDislikes()->where([
             'type_id' => LikeType::LIKE,
-            'user_id' => auth()->id()
+            'user_id' => auth()->id(),
         ]);
     }
-
 
     /**
     * Collection of dislikes on this record by the logged in user.
@@ -110,10 +109,9 @@ trait Likeable
     {
         return $this->likesAndDislikes()->where([
             'type_id' => LikeType::DISLIKE,
-            'user_id' => auth()->id()
+            'user_id' => auth()->id(),
         ]);
     }
-
 
     /**
     * Collection of dislikes on this record by the logged in user.
@@ -123,7 +121,7 @@ trait Likeable
     public function userLikesAndDislikes()
     {
         return $this->likesAndDislikes()->where([
-            'user_id' => auth()->id()
+            'user_id' => auth()->id(),
         ]);
     }
 

--- a/tests/Unit/Traits/LikeableTest.php
+++ b/tests/Unit/Traits/LikeableTest.php
@@ -468,7 +468,6 @@ class LikeableTest extends TestCase
 
         $this->assertEquals($user->id, $entities->skip(1)->first()->userLikesAndDislikes[0]->user_id);
         $this->assertEquals(LikeTYpe::DISLIKE, $entities->skip(1)->first()->userLikesAndDislikes[0]->type_id);
-
     }
 
     /** @test */

--- a/tests/Unit/Traits/LikeableTest.php
+++ b/tests/Unit/Traits/LikeableTest.php
@@ -14,6 +14,7 @@ namespace Cog\Likeable\Tests\Unit;
 use Cog\Likeable\Contracts\Like as LikeContract;
 use Cog\Likeable\Tests\Stubs\Models\Entity;
 use Cog\Likeable\Tests\Stubs\Models\User;
+use Cog\Likeable\Enums\LikeType;
 use Cog\Likeable\Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -419,6 +420,62 @@ class LikeableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_userlikes_relation()
+    {
+        $user = factory(User::class)->create();
+        $this->actingAs($user);
+
+        $entity = factory(Entity::class)->create();
+        $entity->like($user->id);
+
+        $this->assertInstanceOf(LikeContract::class, $entity->userLikes->first());
+        $this->assertCount(1, $entity->userLikes);
+        $this->assertEquals($user->id, $entity->userLikes->first()->user_id);
+    }
+
+
+    /** @test */
+    public function it_can_get_userdislikes_relation()
+    {
+        $user = factory(User::class)->create();
+        $this->actingAs($user);
+
+        $entity = factory(Entity::class)->create();
+        $entity->dislike($user->id);
+
+        $this->assertInstanceOf(LikeContract::class, $entity->userDislikes->first());
+        $this->assertCount(1, $entity->userDislikes);
+        $this->assertEquals($user->id, $entity->userDislikes->first()->user_id);
+    }
+
+
+
+    /** @test */
+    public function it_can_get_userlikesanddislikes_relation()
+    {
+        $user = factory(User::class)->create();
+        $this->actingAs($user);
+
+        $likeEntity = factory(Entity::class)->create();
+        $likeEntity->like($user->id);
+
+        $dislikeEntity = factory(Entity::class)->create();
+        $dislikeEntity->dislike($user->id);
+
+        $entities = Entity::with('userLikesAndDislikes');
+
+        $this->assertEquals($user->id, $entities->first()->userLikesAndDislikes[0]->user_id);
+        $this->assertEquals(LikeType::LIKE, $entities->first()->userLikesAndDislikes[0]->type_id);
+
+        $entities = Entity::with('userLikesAndDislikes');
+
+        $this->assertEquals($user->id, $entities->skip(1)->first()->userLikesAndDislikes[0]->user_id);
+        $this->assertEquals(LikeTYpe::DISLIKE, $entities->skip(1)->first()->userLikesAndDislikes[0]->type_id);
+
+    }
+
+
+    /** @test */
     public function it_can_get_dislikes_and_likes_relation()
     {
         $entity = factory(Entity::class)->create();
@@ -441,6 +498,9 @@ class LikeableTest extends TestCase
 
         $this->assertEquals(-1, $entity->likesDiffDislikesCount);
     }
+
+
+
 
     /** @test */
     public function it_can_sort_entities_desc_by_likes_count()

--- a/tests/Unit/Traits/LikeableTest.php
+++ b/tests/Unit/Traits/LikeableTest.php
@@ -433,7 +433,6 @@ class LikeableTest extends TestCase
         $this->assertEquals($user->id, $entity->userLikes->first()->user_id);
     }
 
-
     /** @test */
     public function it_can_get_userdislikes_relation()
     {
@@ -447,8 +446,6 @@ class LikeableTest extends TestCase
         $this->assertCount(1, $entity->userDislikes);
         $this->assertEquals($user->id, $entity->userDislikes->first()->user_id);
     }
-
-
 
     /** @test */
     public function it_can_get_userlikesanddislikes_relation()
@@ -474,7 +471,6 @@ class LikeableTest extends TestCase
 
     }
 
-
     /** @test */
     public function it_can_get_dislikes_and_likes_relation()
     {
@@ -498,9 +494,6 @@ class LikeableTest extends TestCase
 
         $this->assertEquals(-1, $entity->likesDiffDislikesCount);
     }
-
-
-
 
     /** @test */
     public function it_can_sort_entities_desc_by_likes_count()


### PR DESCRIPTION
Addresses #27 , allows you to get like/dislike data for the current logged in user without having to iterate and check `->liked` for each row, minimizing query count.