### PR TITLE
Use eager loaded relations for check if model was liked\disliked first

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -5,3 +5,4 @@ disabled:
   - phpdoc_no_package
   - logical_not_operators_with_successor_space
   - length_ordered_imports
+  - simplified_null_return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-likeable` will be documented in this file.
 
+## [3.1.0] - 2017-12-28
+
+### Changed
+
+- Checks if model liked by user will try to search in eager loaded relations first.
+
 ## [3.0.0] - 2017-08-24
 
 ### Added
@@ -95,6 +101,7 @@ All notable changes to `laravel-likeable` will be documented in this file.
 
 - Initial release
 
+[3.0.0]: https://github.com/cybercog/laravel-likeable/compare/2.2.5...3.0.0
 [2.2.5]: https://github.com/cybercog/laravel-likeable/compare/2.2.4...2.2.5
 [2.2.4]: https://github.com/cybercog/laravel-likeable/compare/2.2.3...2.2.4
 [2.2.3]: https://github.com/cybercog/laravel-likeable/compare/2.2.2...2.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `laravel-likeable` will be documented in this file.
 
 ### Changed
 
-- Checks if model liked by user will try to search in eager loaded relations first.
+- Checks if model liked by user will try to search in eager loaded relations first
 
 ## [3.0.0] - 2017-08-24
 
@@ -101,6 +101,7 @@ All notable changes to `laravel-likeable` will be documented in this file.
 
 - Initial release
 
+[3.1.0]: https://github.com/cybercog/laravel-likeable/compare/3.0.0...3.1.0
 [3.0.0]: https://github.com/cybercog/laravel-likeable/compare/2.2.5...3.0.0
 [2.2.5]: https://github.com/cybercog/laravel-likeable/compare/2.2.4...2.2.5
 [2.2.4]: https://github.com/cybercog/laravel-likeable/compare/2.2.3...2.2.4

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ $article->liked(); // current user
 $article->liked($user->id);
 ```
 
+*Checks in eager loaded relations `likes` & `likesAndDislikes` first.*
+
 ##### Get collection of users who liked model
 
 ```php
@@ -218,6 +220,8 @@ $article->disliked(); // current user
 $article->disliked($user->id);
 ```
 
+*Checks in eager loaded relations `dislikes` & `likesAndDislikes` first.*
+
 ##### Get collection of users who disliked model
 
 ```php
@@ -248,21 +252,6 @@ $article->likesAndDislikes();
 
 ```php
 $article->likesAndDislikes;
-```
-
-#### Logged in User iterable Likes and Dislikes
-
-##### Iterate through likes of the current logged in user
-```php
-$article->userLikes;
-```
-##### Iterate through dislikes of the current logged in user
-```php
-$article->userDislikes;
-```
-##### Iterate through likes and dislikes of the current logged in user
-```php
-$article->userLikesAndDislikes;
 ```
 
 ### Scopes

--- a/src/Traits/Likeable.php
+++ b/src/Traits/Likeable.php
@@ -88,44 +88,6 @@ trait Likeable
     }
 
     /**
-     * Collection of likes on this record by the logged in user.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
-     */
-    public function userLikes()
-    {
-        return $this->likesAndDislikes()->where([
-            'type_id' => LikeType::LIKE,
-            'user_id' => auth()->id(),
-        ]);
-    }
-
-    /**
-     * Collection of dislikes on this record by the logged in user.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
-     */
-    public function userDislikes()
-    {
-        return $this->likesAndDislikes()->where([
-            'type_id' => LikeType::DISLIKE,
-            'user_id' => auth()->id(),
-        ]);
-    }
-
-    /**
-     * Collection of likes and dislikes on this record by the logged in user.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
-     */
-    public function userLikesAndDislikes()
-    {
-        return $this->likesAndDislikes()->where([
-            'user_id' => auth()->id(),
-        ]);
-    }
-
-    /**
      * Fetch users who liked entity.
      *
      * @return \Illuminate\Support\Collection


### PR DESCRIPTION
This PR reverts changes from PR #28. This changes weren't published in any release, so it's not breaking change.

@acidjazz thank you for pointing to an issue with n+1 queries when checking if model's collection was liked by user even if relationship was eager loaded.

I've refactored `isLiked` method in `LikeableService` class:
1. First of all it checks what type of check should be done
2. On `like` type we are checking `likes` & `likesAndDislikes` relationships are loaded, on `dislike` type we are checking `dislikes` & `likesAndDislikes` relationships are loaded.
3. If relationships described above are eager loaded then search will be performed in fetched collection instead of making new query for each model.
4. If relationship not loaded - additional query for each model will be produced.

In example:
```php
$articles = Article::all();
foreach ($articles as $article) {
    dump($article->liked());
}
```
If we had collection of 3 likeable models then 5 queries will be executed. To optimize it we can use eager loading.

```php
$articles = Article::with('likes')->get();
foreach ($articles as $article) {
    dump($article->liked());
}
```
Now only 2 queries will be executed.

But if we will have only `dislikes` relation eager loaded and try to check if models were `liked` then we'll perform 5 queries as if no relations were eager loaded.

Eager loaded `likesAndDislikes` relation work for both methods `liked()` and `disliked()`.